### PR TITLE
Fix off-by-one errors

### DIFF
--- a/H3VRUtilities/src/ObjectModifiers/AlternatingMag/AlternatingMagsHandler.cs
+++ b/H3VRUtilities/src/ObjectModifiers/AlternatingMag/AlternatingMagsHandler.cs
@@ -24,21 +24,26 @@ namespace H3VRUtils.AlternatingMags
 		{
 			if (OverrideMagToChange == -1)
 			{
-				OverrideMagToChange = activeMagMount += 1;
-				if(activeMagMount > MagMounts.Count)
+				activeMagMount += 1;
+				if (activeMagMount >= MagMounts.Count)
 				{
 					activeMagMount = 0;
 				}
 			}
-			activeMagMount = OverrideMagToChange;
+			else
+			{
+				activeMagMount = OverrideMagToChange;
+			}
 			for (int i = 0; i < MagMounts.Count; i++)
 			{
-				if (i == OverrideMagToChange)
+				if (i == activeMagMount)
 				{
 					MagMounts[i].SetActivity(true);
 				}
 				else
+				{
 					MagMounts[i].SetActivity(false);
+				}
 			}
 		}
 

--- a/H3VRUtilities/src/ObjectModifiers/FirearmModifiers/CycleOnBoltRelease.cs
+++ b/H3VRUtilities/src/ObjectModifiers/FirearmModifiers/CycleOnBoltRelease.cs
@@ -21,7 +21,7 @@ namespace H3VRUtils.MonoScripts.VisualModifiers
 			if(wasFull && !chamber.IsFull)
 			{
 				pointer++;
-				if (pointer > Locs.Count) pointer = 0;
+				if (pointer >= Locs.Count) pointer = 0;
 				muzzle.transform.position = Locs[pointer].position;
 				muzzle.transform.rotation = Locs[pointer].rotation;
 			}

--- a/H3VRUtilities/src/Visuals/MagFollower.cs
+++ b/H3VRUtilities/src/Visuals/MagFollower.cs
@@ -80,7 +80,7 @@ namespace H3VRUtils
 
 			if (UsesIndivdualPointMagFollower)
 			{
-				if (Positions.Count < magazine.m_numRounds)
+				if (Positions.Count <= magazine.m_numRounds)
 				{
 					return;
 				}
@@ -93,7 +93,7 @@ namespace H3VRUtils
 			}
 			else if (UsesIndividualMeshReplacement)
 			{
-				if (Meshes.Count < magazine.m_numRounds)
+				if (Meshes.Count <= magazine.m_numRounds)
 				{
 					return;
 				}


### PR DESCRIPTION
MagFollower:
- If m_numRounds == Count, then Positions[m_numRounds] and Meshes[m_numRounds] will be out of bounds, because the last index is Count - 1

CycleOnBoltRelease:
- If pointer == Locs.Count, then Locs[pointer] will be out of bounds

AlternatingMagsHandler:
- If activeMagMount == MagMounts.Count, then MagMounts[activeMagMount] will be out of bounds
- Even if activeMagMount goes out of bounds and is set back to 0, OverrideMagToChange is still out of bounds because it hasn't been corrected
- It's clearer to use activeMagMount as the index in the for loop